### PR TITLE
arm64: dts: qcom: Disable AVB for sdm845

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm845.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845.dtsi
@@ -507,7 +507,7 @@
 					dev = "/dev/block/platform/soc/1d84000.ufshc/by-name/vendor";
 					type = "ext4";
 					mnt_flags = "ro,barrier=1,discard";
-					fsmgr_flags = "wait,slotselect,avb";
+					fsmgr_flags = "wait,slotselect";
 				};
 			};
 		};


### PR DESCRIPTION
I don't understand why it works for Lineage and not me but this tree is
supposed to be minimal maintenance so I'm not looking into it further.

Signed-off-by: Nathan Chancellor <natechancellor@gmail.com>